### PR TITLE
Custom debug panel

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -12,8 +12,8 @@ module.exports = Debug =
 	atomToolbar: null
 	sidebar: null
 	atomSidebar: null
+	customDebugView: null
 	customDebugPanel: null
-	atomCustomDebugPanel: null
 	disposable: null
 	buggers: []
 	activeBugger: null

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -46,7 +46,7 @@ module.exports = Debug =
 
 		@sidebar = new Sidebar this
 		@atomSidebar = atom.workspace.addRightPanel item: @sidebar.getElement(), visible: false, priority:200
-		
+
 		@customDebugView = new Custom this
 		@customDebugPanel = atom.workspace.addBottomPanel item: @customDebugView.getElement(), visible: false, priority:200
 		@customDebugView.emitter.on 'close', =>
@@ -140,10 +140,10 @@ module.exports = Debug =
 	hide: ->
 		@atomToolbar?.hide()
 		@atomSidebar?.hide()
-		
+
 	customDebug: ->
 		@customDebugPanel.show()
-			
+
 	customDebugHide: ->
 		@customDebugPanel?.hide()
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -48,7 +48,8 @@ module.exports = Debug =
 		@atomSidebar = atom.workspace.addRightPanel item: @sidebar.getElement(), visible: false, priority:200
 		
 		@customDebugView = new Custom this
-		@atomCustomDebugView = atom.workspace.addBottomPanel item: @customDebugView.getElement(), visible: false, priority:200
+		@customDebugPanel = atom.workspace.addBottomPanel item: @customDebugView.getElement(), visible: false, priority:200
+		@customDebugView.setPanel(@customDebugPanel)
 
 		@disposable = new CompositeDisposable
 		@disposable.add atom.commands.add 'atom-workspace', 'dbg:custom-debug': => @customDebug()
@@ -66,6 +67,12 @@ module.exports = Debug =
 				@toggleBreakpoint textEditor.getPath(), pos.row+1
 		@disposable.add atom.commands.add 'atom-workspace', 'dbg:clear-breakpoints': =>
 			@clearBreakpoints()
+		
+		# @disposable.add atom.commands.add @customDebugPanel, 'dbg:stop': => @stop()
+		# 
+		# @subscriptions.add atom.commands.add @element,
+    #   'core:close': => @panel?hide()
+    #   'core:cancel': => @panel?hide()
 
 		@disposable.add atom.workspace.observeTextEditors (textEditor) =>
 			path = textEditor.getPath()
@@ -139,10 +146,10 @@ module.exports = Debug =
 		@atomSidebar?.hide()
 		
 	customDebug: ->
-		if @atomCustomDebugView.isVisible()
-      @atomCustomDebugView.hide()
-    else
-      @atomCustomDebugView.show()
+		@customDebugPanel.show()
+			
+	customDebugHide: ->
+		@customDebugPanel?.hide()
 
 	continue: ->
 		unless @ui.isPaused then return

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -254,6 +254,7 @@ module.exports = Debug =
 
 	consumeDbgProvider: (debug) ->
 		@buggers.push debug
+		@customDebugView.addDebuggerOption(debug.name)
 
 	provideDbg: ->
 		return @provider

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,6 +1,7 @@
 Ui = require './Ui'
 Toolbar = require './view/Toolbar'
 Sidebar = require './view/Sidebar'
+Custom = require './view/Custom'
 
 {CompositeDisposable, Emitter} = require 'atom'
 
@@ -11,6 +12,8 @@ module.exports = Debug =
 	atomToolbar: null
 	sidebar: null
 	atomSidebar: null
+	customDebugPanel: null
+	atomCustomDebugPanel: null
 	disposable: null
 	buggers: []
 	activeBugger: null
@@ -43,8 +46,12 @@ module.exports = Debug =
 
 		@sidebar = new Sidebar this
 		@atomSidebar = atom.workspace.addRightPanel item: @sidebar.getElement(), visible: false, priority:200
+		
+		@CustomDebugView = new Custom this
+		@CustomDebugView = atom.workspace.addRightPanel item: @sidebar.getElement(), visible: false, priority:200
 
 		@disposable = new CompositeDisposable
+		@disposable.add atom.commands.add 'atom-workspace', 'dbg:custom-debug': => @customDebug()
 		@disposable.add atom.commands.add 'atom-workspace', 'dbg:stop': => @stop()
 		@disposable.add atom.commands.add 'atom-workspace', 'dbg:continue': => @continue()
 		@disposable.add atom.commands.add 'atom-workspace', 'dbg:pause': => @pause()
@@ -130,6 +137,12 @@ module.exports = Debug =
 	hide: ->
 		@atomToolbar?.hide()
 		@atomSidebar?.hide()
+		
+	customDebug: ->
+		if @CustomDebugView.isVisible()
+      @CustomDebugView.hide()
+    else
+      @CustomDebugView.show()
 
 	continue: ->
 		unless @ui.isPaused then return

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -47,8 +47,8 @@ module.exports = Debug =
 		@sidebar = new Sidebar this
 		@atomSidebar = atom.workspace.addRightPanel item: @sidebar.getElement(), visible: false, priority:200
 		
-		@CustomDebugView = new Custom this
-		@CustomDebugView = atom.workspace.addRightPanel item: @sidebar.getElement(), visible: false, priority:200
+		@customDebugView = new Custom this
+		@atomCustomDebugView = atom.workspace.addBottomPanel item: @customDebugView.getElement(), visible: false, priority:200
 
 		@disposable = new CompositeDisposable
 		@disposable.add atom.commands.add 'atom-workspace', 'dbg:custom-debug': => @customDebug()
@@ -139,10 +139,10 @@ module.exports = Debug =
 		@atomSidebar?.hide()
 		
 	customDebug: ->
-		if @CustomDebugView.isVisible()
-      @CustomDebugView.hide()
+		if @atomCustomDebugView.isVisible()
+      @atomCustomDebugView.hide()
     else
-      @CustomDebugView.show()
+      @atomCustomDebugView.show()
 
 	continue: ->
 		unless @ui.isPaused then return

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -49,7 +49,8 @@ module.exports = Debug =
 		
 		@customDebugView = new Custom this
 		@customDebugPanel = atom.workspace.addBottomPanel item: @customDebugView.getElement(), visible: false, priority:200
-		@customDebugView.setPanel(@customDebugPanel)
+		@customDebugView.emitter.on 'close', =>
+			@customDebugPanel.hide()
 
 		@disposable = new CompositeDisposable
 		@disposable.add atom.commands.add 'atom-workspace', 'dbg:custom-debug': => @customDebug()
@@ -67,12 +68,7 @@ module.exports = Debug =
 				@toggleBreakpoint textEditor.getPath(), pos.row+1
 		@disposable.add atom.commands.add 'atom-workspace', 'dbg:clear-breakpoints': =>
 			@clearBreakpoints()
-		
-		# @disposable.add atom.commands.add @customDebugPanel, 'dbg:stop': => @stop()
-		# 
-		# @subscriptions.add atom.commands.add @element,
-    #   'core:close': => @panel?hide()
-    #   'core:cancel': => @panel?hide()
+		@disposable.add atom.commands.add 'atom-workspace', 'core:cancel': => @customDebugPanel.hide()
 
 		@disposable.add atom.workspace.observeTextEditors (textEditor) =>
 			path = textEditor.getPath()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -144,9 +144,6 @@ module.exports = Debug =
 	customDebug: ->
 		@customDebugPanel.show()
 
-	customDebugHide: ->
-		@customDebugPanel?.hide()
-
 	continue: ->
 		unless @ui.isPaused then return
 		@activeBugger?.continue()

--- a/lib/view/Custom.coffee
+++ b/lib/view/Custom.coffee
@@ -1,11 +1,33 @@
+{CompositeDisposable} = require 'atom'
+
 module.exports =
 class CustomDebugView
+  panel = null
+  
   constructor: (serializedState) ->
-    # @subscriptions = new CompositeDisposable()
+    @subscriptions = new CompositeDisposable()
     
+    @content()
+    @handleEvents()
+    
+  handleEvents: ->
+    @subscriptions.add atom.commands.add @element,
+      'core:close': => @panel?hide()
+      'core:cancel': => @panel?hide()
+    
+  content: ->
     # Create root element
     @element = document.createElement('div')
+    @element.setAttribute("tabIndex", -1)
     @element.classList.add('debug-custom')
+    
+    header = document.createElement('header')
+    header.classList.add 'header'
+    span = document.createElement('span')
+    span.classList.add 'header-item', 'description'
+    span.textContent = "Configure Debug Session"
+    @element.appendChild header
+    header.appendChild span
     
     # debugger - Optional. The name of the dbg provider to use. (This can be omitted to auto-detect)
     # path - Optional. The path to the file to debug
@@ -14,65 +36,67 @@ class CustomDebugView
     # ... - Optional. Custom debugger arguments
   
     # file to Debug
+    section = document.createElement 'section'
+    section.classList.add 'input-block'
     fileGroup = document.createElement 'div'
-    fileGroup.classList.add 'block'
-    @element.appendChild fileGroup
-    
-    # pathLabel = document.createElement 'label'
-    # pathLabel.textContent = "File to Debug"
-    # pathLabel.classList.add 'inline-block'
-    # fileGroup.appendChild pathLabel
-    
+    fileGroup.classList.add 'input-block-item', 'input-block-item--flex', 'editor-container'
+    @element.appendChild section
+    section.appendChild fileGroup
+
     @pathInput = document.createElement 'atom-text-editor'
-    @pathInput.setAttribute(name, value) for name, value of {"tabIndex": -1, "mini": true, "placeholder-text": "Path to the file to debug"}
-    # @pathInput.classList.add 'inline-block', 'input-text'
+    @pathInput.setAttribute(name, value) for name, value of {"mini": true, "placeholder-text": "Path to the file to debug"}
     @pathInput.type = "text"
-    # @subscriptions.add atom.tooltips.add @pathInput, title: 'File to Debug'
     fileGroup.appendChild @pathInput
-    
+
+    div = document.createElement 'div'
+    div.classList.add 'input-block-item'
+    bgroup = document.createElement 'div'
+    bgroup.classList.add 'btn-group'
     @pathButton = document.createElement 'button'
-    @pathButton.classList.add 'inline-block', 'btn', 'icon', 'icon-file-directory'
+    @pathButton.classList.add 'btn', 'icon', 'icon-file-directory'
     # @pathButton.addEventListener 'click', -> bugger.continue()
     # @subscriptions.add atom.tooltips.add @pathButton, title: 'Choose File to Debug'
-    fileGroup.appendChild @pathButton
+    section.appendChild div
+    div.appendChild bgroup
+    bgroup.appendChild @pathButton
 
-    # args
+    # file args
+    section = document.createElement 'section'
+    section.classList.add 'input-block'
     argsGroup = document.createElement 'div'
-    argsGroup.classList.add 'block'
-    @element.appendChild argsGroup
-    
-    # argsLabel = document.createElement 'label'
-    # argsLabel.textContent = "Arguments"
-    # argsLabel.classList.add 'inline-block'
-    # argsGroup.appendChild argsLabel
-    
+    argsGroup.classList.add 'input-block-item', 'input-block-item--flex', 'editor-container'
+    @element.appendChild section
+    section.appendChild argsGroup
+
     @argsInput = document.createElement 'atom-text-editor'
-    @argsInput.setAttribute(name, value) for name, value of {"tabIndex": -1, "mini": true, "placeholder-text": "Arguments to pass to the file being debugged"}
-    # @argsInput.classList.add 'inline-block', 'input-text'
-    # @subscriptions.add atom.tooltips.add @argsInput, title: 'Debugger arguements'
+    @argsInput.setAttribute(name, value) for name, value of {"mini": true, "placeholder-text": "Arguments to pass to the file being debugged"}
+    @argsInput.type = "text"
     argsGroup.appendChild @argsInput
-    
+
     # working directory for debugger
+    section = document.createElement 'section'
+    section.classList.add 'input-block'
     cwdGroup = document.createElement 'div'
-    cwdGroup.classList.add 'block'
-    @element.appendChild cwdGroup
-    
-    # cwdLabel = document.createElement 'label'
-    # cwdLabel.classList.add 'inline-block'
-    # cwdLabel.textContent = "Working Directory"
-    # cwdGroup.appendChild cwdLabel
-        
+    cwdGroup.classList.add 'input-block-item', 'input-block-item--flex', 'editor-container'
+    @element.appendChild section
+    section.appendChild cwdGroup
+
     @cwdInput = document.createElement 'atom-text-editor'
-    @cwdInput.setAttribute(name, value) for name, value of {"tabIndex": -1, "mini": true, "placeholder-text": "Working directory to use when debugging"}
-    # @cwdInput.classList.add 'inline-block', 'editor', 'mini'
-    # @subscriptions.add atom.tooltips.add @cwdInput, title: 'Working directory path'
+    @cwdInput.setAttribute(name, value) for name, value of {"mini": true, "placeholder-text": "Working directory to use when debugging"}
+    @cwdInput.type = "text"
     cwdGroup.appendChild @cwdInput
-    
+
+    div = document.createElement 'div'
+    div.classList.add 'input-block-item'
+    bgroup = document.createElement 'div'
+    bgroup.classList.add 'btn-group'
     @cwdButton = document.createElement 'button'
-    @cwdButton.classList.add 'inline-block', 'btn', 'icon', 'icon-file-directory'
+    @cwdButton.classList.add 'btn', 'icon', 'icon-file-directory'
     # @cwdButton.addEventListener 'click', -> bugger.continue()
-    # @subscriptions.add atom.tooltips.add @cwdButton, title: 'Choose working directory'
-    cwdGroup.appendChild @cwdButton
+    # @subscriptions.add atom.tooltips.add @cwdButton, title: 'Choose File to Debug'
+    section.appendChild div
+    div.appendChild bgroup
+    bgroup.appendChild @cwdButton
     
     # Start Button
     startGroup = document.createElement 'div'
@@ -86,12 +110,14 @@ class CustomDebugView
     # @subscriptions.add atom.tooltips.add @startButton, title: 'Choose working directory'
     startGroup.appendChild @startButton
 
+  setPanel: (@panel) ->
+  
   # Returns an object that can be retrieved when package is activated
   serialize: ->
 
   # Tear down any state and detach
   destroy: ->
-    # @subscriptions.dispose()
+    @subscriptions.dispose()
     @element.remove()
 
   getElement: ->

--- a/lib/view/Custom.coffee
+++ b/lib/view/Custom.coffee
@@ -1,0 +1,22 @@
+module.exports =
+class CustomDebugView
+  constructor: (serializedState) ->
+    # Create root element
+    @element = document.createElement('div')
+    @element.classList.add('debug-custom')
+
+    # Create message element
+    message = document.createElement('div')
+    message.textContent = "The Your Name Word Count package is Alive! It's ALIVE!"
+    message.classList.add('message')
+    @element.appendChild(message)
+
+  # Returns an object that can be retrieved when package is activated
+  serialize: ->
+
+  # Tear down any state and detach
+  destroy: ->
+    @element.remove()
+
+  getElement: ->
+    @element

--- a/lib/view/Custom.coffee
+++ b/lib/view/Custom.coffee
@@ -3,188 +3,187 @@ path = require('path');
 
 module.exports =
 class CustomDebugView
-  bugger = null
+	bugger = null
 
-  constructor: (bugger) ->
-    @emitter = new Emitter()
-    @bugger = bugger
-    @content()
+	constructor: (bugger) ->
+		@emitter = new Emitter()
+		@bugger = bugger
+		@content()
 
-  content: ->
-    # Create root element
-    @element = document.createElement 'div'
-    @element.setAttribute("tabIndex", -1)
-    @element.classList.add('debug-custom')
+	content: ->
+		@element = document.createElement 'div'
+		@element.setAttribute "tabIndex", -1
+		@element.classList.add 'debug-custom'
 
-    header = document.createElement 'div'
-    header.classList.add 'panel-heading'
-    header.textContent = "Configure Debug Session"
-    @element.appendChild header
+		header = document.createElement 'div'
+		header.classList.add 'panel-heading'
+		header.textContent = "Configure Debug Session"
+		@element.appendChild header
 
-    closeButton = document.createElement 'button'
-    closeButton.classList.add 'btn', 'action-close', 'icon', 'icon-remove-close'
-    header.appendChild closeButton
+		closeButton = document.createElement 'button'
+		closeButton.classList.add 'btn', 'action-close', 'icon', 'icon-remove-close'
+		header.appendChild closeButton
 
-    closeButton.addEventListener 'click', =>
-      @emitter.emit 'close'
+		closeButton.addEventListener 'click', =>
+			@emitter.emit 'close'
 
-    div = document.createElement('div')
-    div.classList.add 'input-block-item', 'labeled-block'
-    label = document.createElement('label')
-    label.textContent = "Select Debugger"
-    div.appendChild label
+		div = document.createElement 'div'
+		div.classList.add 'input-block-item', 'labeled-block'
+		label = document.createElement 'label'
+		label.textContent = "Select Debugger"
+		div.appendChild label
 
-    @selectDebugger = document.createElement('select')
-    @selectDebugger.classList.add 'input-select', 'input-select-item'
-    @element.appendChild div
-    div.appendChild @selectDebugger
+		@selectDebugger = document.createElement 'select'
+		@selectDebugger.classList.add 'input-select', 'input-select-item'
+		@element.appendChild div
+		div.appendChild @selectDebugger
 
-    option = document.createElement('option')
-    option.textContent = "auto"
-    @selectDebugger.appendChild option
+		option = document.createElement 'option'
+		option.textContent = "auto"
+		@selectDebugger.appendChild option
 
-    body = document.createElement('div')
-    body.classList.add('body')
-    inputBody = document.createElement('div')
-    inputBody.classList.add 'input-inline-block'
-    body.appendChild inputBody
+		body = document.createElement 'div'
+		body.classList.add 'body'
+		inputBody = document.createElement 'div'
+		inputBody.classList.add 'input-inline-block'
+		body.appendChild inputBody
 
-    # file to Debug
-    section = document.createElement 'section'
-    section.classList.add 'input-block'
-    fileGroup = document.createElement 'div'
-    fileGroup.classList.add 'input-block-item', 'input-block-item--flex', 'editor-container'
-    inputBody.appendChild section
-    section.appendChild fileGroup
+		# file to Debug
+		section = document.createElement 'section'
+		section.classList.add 'input-block'
+		fileGroup = document.createElement 'div'
+		fileGroup.classList.add 'input-block-item', 'input-block-item--flex', 'editor-container'
+		inputBody.appendChild section
+		section.appendChild fileGroup
 
-    @pathInput = document.createElement 'atom-text-editor'
-    @pathInput.setAttribute(name, value) for name, value of {"mini": true, "placeholder-text": "Path to the file to debug"}
-    @pathInput.type = "text"
-    fileGroup.appendChild @pathInput
+		@pathInput = document.createElement 'atom-text-editor'
+		@pathInput.setAttribute(name, value) for name, value of {"mini": true, "placeholder-text": "Path to the file to debug"}
+		@pathInput.type = "text"
+		fileGroup.appendChild @pathInput
 
-    div = document.createElement 'div'
-    div.classList.add 'input-block-item'
-    bgroup = document.createElement 'div'
-    bgroup.classList.add 'btn-group'
-    pathButton = document.createElement 'button'
-    pathButton.classList.add 'btn-item', 'btn', 'icon', 'icon-file-binary'
-    pathButton.textContent = "Choose File"
-    pathButton.addEventListener 'click', => @pickFile()
-    section.appendChild div
-    div.appendChild bgroup
-    bgroup.appendChild pathButton
+		div = document.createElement 'div'
+		div.classList.add 'input-block-item'
+		bgroup = document.createElement 'div'
+		bgroup.classList.add 'btn-group'
+		pathButton = document.createElement 'button'
+		pathButton.classList.add 'btn-item', 'btn', 'icon', 'icon-file-binary'
+		pathButton.textContent = "Choose File"
+		pathButton.addEventListener 'click', => @pickFile()
+		section.appendChild div
+		div.appendChild bgroup
+		bgroup.appendChild pathButton
 
-    # file args
-    section = document.createElement 'section'
-    section.classList.add 'input-block'
-    argsGroup = document.createElement 'div'
-    argsGroup.classList.add 'input-block-item', 'input-block-item--flex', 'editor-container'
-    inputBody.appendChild section
-    section.appendChild argsGroup
+		# file args
+		section = document.createElement 'section'
+		section.classList.add 'input-block'
+		argsGroup = document.createElement 'div'
+		argsGroup.classList.add 'input-block-item', 'input-block-item--flex', 'editor-container'
+		inputBody.appendChild section
+		section.appendChild argsGroup
 
-    @argsInput = document.createElement 'atom-text-editor'
-    @argsInput.setAttribute(name, value) for name, value of {"mini": true, "placeholder-text": "Optional: Arguments to pass to the file being debugged"}
-    @argsInput.type = "text"
-    argsGroup.appendChild @argsInput
+		@argsInput = document.createElement 'atom-text-editor'
+		@argsInput.setAttribute(name, value) for name, value of {"mini": true, "placeholder-text": "Optional: Arguments to pass to the file being debugged"}
+		@argsInput.type = "text"
+		argsGroup.appendChild @argsInput
 
-    # working directory for debugger
-    section = document.createElement 'section'
-    section.classList.add 'input-block'
-    cwdGroup = document.createElement 'div'
-    cwdGroup.classList.add 'input-block-item', 'input-block-item--flex', 'editor-container'
-    inputBody.appendChild section
-    section.appendChild cwdGroup
+		# working directory for debugger
+		section = document.createElement 'section'
+		section.classList.add 'input-block'
+		cwdGroup = document.createElement 'div'
+		cwdGroup.classList.add 'input-block-item', 'input-block-item--flex', 'editor-container'
+		inputBody.appendChild section
+		section.appendChild cwdGroup
 
-    @cwdInput = document.createElement 'atom-text-editor'
-    @cwdInput.setAttribute(name, value) for name, value of {"mini": true, "placeholder-text": "Optional: Working directory to use when debugging"}
-    @cwdInput.type = "text"
-    cwdGroup.appendChild @cwdInput
+		@cwdInput = document.createElement 'atom-text-editor'
+		@cwdInput.setAttribute(name, value) for name, value of {"mini": true, "placeholder-text": "Optional: Working directory to use when debugging"}
+		@cwdInput.type = "text"
+		cwdGroup.appendChild @cwdInput
 
-    div = document.createElement 'div'
-    div.classList.add 'input-block-item'
-    bgroup = document.createElement 'div'
-    bgroup.classList.add 'btn-group'
-    cwdButton = document.createElement 'button'
-    cwdButton.classList.add 'btn-item', 'btn', 'icon', 'icon-file-directory'
-    cwdButton.textContent = "Choose Directory"
-    cwdButton.addEventListener 'click', => @pickCwd()
-    section.appendChild div
-    div.appendChild bgroup
-    bgroup.appendChild cwdButton
+		div = document.createElement 'div'
+		div.classList.add 'input-block-item'
+		bgroup = document.createElement 'div'
+		bgroup.classList.add 'btn-group'
+		cwdButton = document.createElement 'button'
+		cwdButton.classList.add 'btn-item', 'btn', 'icon', 'icon-file-directory'
+		cwdButton.textContent = "Choose Directory"
+		cwdButton.addEventListener 'click', => @pickCwd()
+		section.appendChild div
+		div.appendChild bgroup
+		bgroup.appendChild cwdButton
 
-    # Start Button
-    div = document.createElement 'div'
-    div.classList.add 'inline-block-start'
-    body.appendChild div
-    @element.appendChild body
+		# Start Button
+		div = document.createElement 'div'
+		div.classList.add 'inline-block-start'
+		body.appendChild div
+		@element.appendChild body
 
-    startButton = document.createElement 'button'
-    startButton.classList.add 'btn-lg', 'btn-success', 'icon', 'icon-chevron-right'
-    startButton.textContent = "Start"
-    startButton.addEventListener 'click', => @startDebugging()
-    div.appendChild startButton
+		startButton = document.createElement 'button'
+		startButton.classList.add 'btn-lg', 'btn-success', 'icon', 'icon-chevron-right'
+		startButton.textContent = "Start"
+		startButton.addEventListener 'click', => @startDebugging()
+		div.appendChild startButton
 
-  pickFile: ->
-    openOptions =
-      properties: ['openFile', 'createDirectory']
-      title: 'Select File'
+	pickFile: ->
+		openOptions =
+			properties: ['openFile', 'createDirectory']
+			title: 'Select File'
 
-    # Show the open dialog as child window on Windows and Linux, and as
-    # independent dialog on macOS. This matches most native apps.
-    parentWindow =
-      if process.platform is 'darwin'
-        null
-      else
-        require('electron').remote.getCurrentWindow()
+		# Show the open dialog as child window on Windows and Linux, and as
+		# independent dialog on macOS. This matches most native apps.
+		parentWindow =
+			if process.platform is 'darwin'
+				null
+			else
+				require('electron').remote.getCurrentWindow()
 
-    # File dialog defaults to project directory of currently active editor
-    {dialog} = require('electron').remote
-    file = dialog.showOpenDialog(parentWindow, openOptions)
-    if file?
-      @pathInput.model.buffer.setText(file[0])
+		# File dialog defaults to project directory of currently active editor
+		{dialog} = require('electron').remote
+		file = dialog.showOpenDialog parentWindow, openOptions
+		if file?
+			@pathInput.model.buffer.setText file[0]
 
-  pickCwd: ->
-    openOptions =
-      properties: ['openDirectory', 'createDirectory']
-      title: 'Select Folder'
+	pickCwd: ->
+		openOptions =
+			properties: ['openDirectory', 'createDirectory']
+			title: 'Select Folder'
 
-    # Show the open dialog as child window on Windows and Linux, and as
-    # independent dialog on macOS. This matches most native apps.
-    parentWindow =
-      if process.platform is 'darwin'
-        null
-      else
-        require('electron').remote.getCurrentWindow()
+		# Show the open dialog as child window on Windows and Linux, and as
+		# independent dialog on macOS. This matches most native apps.
+		parentWindow =
+			if process.platform is 'darwin'
+				null
+			else
+				require('electron').remote.getCurrentWindow()
 
-    # File dialog defaults to project directory of currently active editor
-    {dialog} = require('electron').remote
-    folder = dialog.showOpenDialog(parentWindow, openOptions)
-    if folder?
-      @cwdInput.model.buffer.setText(folder[0])
+		# File dialog defaults to project directory of currently active editor
+		{dialog} = require('electron').remote
+		folder = dialog.showOpenDialog parentWindow, openOptions
+		if folder?
+			@cwdInput.model.buffer.setText folder[0]
 
-  addDebuggerOption: (name) ->
-    option = document.createElement('option')
-    option.textContent = name
-    @selectDebugger.appendChild option
+	addDebuggerOption: (name) ->
+		option = document.createElement 'option'
+		option.textContent = name
+		@selectDebugger.appendChild option
 
-  startDebugging: ->
-    options = {debugger : null, path: null, args : null, cwd : null}
-    if @pathInput.model.buffer.lines[0] != ""
-      options.path = @pathInput.model.buffer.lines[0]
-    else
-      return
-    if @selectDebugger.value != "auto"
-      options.debugger = @selectDebugger.value
-    if @argsInput.model.buffer.lines[0] != ""
-      options.args = [ @argsInput.model.buffer.lines[0] ] # TODO: parse into args?
-    if @cwdInput.model.buffer.lines[0] != ""
-      options.cwd = @cwdInput.model.buffer.lines[0]
-    @emitter.emit 'close'
-    @bugger.debug(options)
+	startDebugging: ->
+		options = {debugger : null, path: null, args : null, cwd : null}
+		if @pathInput.model.buffer.lines[0] != ""
+			options.path = @pathInput.model.buffer.lines[0]
+		else
+			return
+		if @selectDebugger.value != "auto"
+			options.debugger = @selectDebugger.value
+		if @argsInput.model.buffer.lines[0] != ""
+			options.args = [ @argsInput.model.buffer.lines[0] ] # TODO: parse into args?
+		if @cwdInput.model.buffer.lines[0] != ""
+			options.cwd = @cwdInput.model.buffer.lines[0]
+		@emitter.emit 'close'
+		@bugger.debug options
 
-  # Tear down any state and detach
-  destroy: ->
-    @element.remove()
+	# Tear down any state and detach
+	destroy: ->
+		@element.remove()
 
-  getElement: ->
-    @element
+	getElement: ->
+		@element

--- a/lib/view/Custom.coffee
+++ b/lib/view/Custom.coffee
@@ -1,70 +1,51 @@
 path = require('path');
-{CompositeDisposable} = require 'atom'
+{Emitter, promptForPath} = require 'atom'
 
 module.exports =
 class CustomDebugView
-  panel = null
   bugger = null
-  
+
   constructor: (bugger) ->
-    @subscriptions = new CompositeDisposable()
+    @emitter = new Emitter()
     @bugger = bugger
-    
     @content()
-    @handleEvents()
-    
-  handleEvents: ->
-    # @subscriptions.add atom.commands.add @element,
-    #   'core:close': => @panel?hide()
-    #   'core:cancel': => @panel?hide()
-    
+
   content: ->
     # Create root element
-    @element = document.createElement('div')
+    @element = document.createElement 'div'
     @element.setAttribute("tabIndex", -1)
     @element.classList.add('debug-custom')
-    
-    header = document.createElement('header')
-    header.classList.add 'header'
-    span = document.createElement('span')
-    span.classList.add 'header-item', 'description'
-    span.textContent = "Configure Debug Session"
+
+    header = document.createElement 'div' 
+    header.classList.add 'panel-heading'
+    header.textContent = "Configure Debug Session"
     @element.appendChild header
-    header.appendChild span
-    
-    @closeBtn = document.createElement('span')
-    @closeBtn.classList.add 'header-item','pull-right','btn', 'icon', 'icon-remove-close'
-    span.appendChild @closeBtn
-      # @span 'Finding with Options: '
-      # @span outlet: 'optionsLabel', class: 'options'
-    # @subscriptions.add atom.tooltips.add @closeBtn, title: 'Choose File to Debug'
-    @closeBtn.addEventListener 'click', => @panel?.hide()
-    
-    # debugger - Optional. The name of the dbg provider to use. (This can be omitted to auto-detect)
-    # path - Optional. The path to the file to debug
-    # args - Optional. An array of arguments to pass to the file being debugged
-    # cwd - Optional. The working directory to use when debugging
-    # ... - Optional. Custom debugger arguments
-    
+
+    closeButton = document.createElement 'button'
+    closeButton.classList.add 'btn', 'action-close', 'icon', 'icon-remove-close'
+    header.appendChild closeButton
+
+    closeButton.addEventListener 'click', =>
+      @emitter.emit 'close'
+
     div = document.createElement('div')
     div.classList.add 'input-block-item', 'input-block-item--flex'
     span = document.createElement('span')
     label = document.createElement('label')
-    # label.classList.add 'header-item'
     label.textContent = "Select Debugger"
     span.appendChild label
     div.appendChild span
-    
+
     @selectDebugger = document.createElement('select')
     @selectDebugger.classList.add 'input-select'
     @element.appendChild div
     div.appendChild span
     span.appendChild @selectDebugger
-    
+
     option = document.createElement('option')
     option.textContent = "auto"
     @selectDebugger.appendChild option
-  
+
     # file to Debug
     section = document.createElement 'section'
     section.classList.add 'input-block'
@@ -82,14 +63,13 @@ class CustomDebugView
     div.classList.add 'input-block-item'
     bgroup = document.createElement 'div'
     bgroup.classList.add 'btn-group'
-    @pathButton = document.createElement 'button'
-    @pathButton.classList.add 'btn', 'icon', 'icon-file-binary'
-    @pathButton.textContent = "Choose File"
-    @pathButton.addEventListener 'click', => @pickFile()
-    # @subscriptions.add atom.tooltips.add @pathButton, title: 'Choose File to Debug'
+    pathButton = document.createElement 'button'
+    pathButton.classList.add 'btn', 'icon', 'icon-file-binary'
+    pathButton.textContent = "Choose File"
+    pathButton.addEventListener 'click', => @pickFile()
     section.appendChild div
     div.appendChild bgroup
-    bgroup.appendChild @pathButton
+    bgroup.appendChild pathButton
 
     # file args
     section = document.createElement 'section'
@@ -100,7 +80,7 @@ class CustomDebugView
     section.appendChild argsGroup
 
     @argsInput = document.createElement 'atom-text-editor'
-    @argsInput.setAttribute(name, value) for name, value of {"mini": true, "placeholder-text": "Arguments to pass to the file being debugged"}
+    @argsInput.setAttribute(name, value) for name, value of {"mini": true, "placeholder-text": "Optional: Arguments to pass to the file being debugged"}
     @argsInput.type = "text"
     argsGroup.appendChild @argsInput
 
@@ -113,7 +93,7 @@ class CustomDebugView
     section.appendChild cwdGroup
 
     @cwdInput = document.createElement 'atom-text-editor'
-    @cwdInput.setAttribute(name, value) for name, value of {"mini": true, "placeholder-text": "Working directory to use when debugging"}
+    @cwdInput.setAttribute(name, value) for name, value of {"mini": true, "placeholder-text": "Optional: Working directory to use when debugging"}
     @cwdInput.type = "text"
     cwdGroup.appendChild @cwdInput
 
@@ -121,41 +101,68 @@ class CustomDebugView
     div.classList.add 'input-block-item'
     bgroup = document.createElement 'div'
     bgroup.classList.add 'btn-group'
-    @cwdButton = document.createElement 'button'
-    @cwdButton.classList.add 'btn', 'icon', 'icon-file-directory'
-    @cwdButton.textContent = "Choose Directory"
-    # @cwdButton.addEventListener 'click', -> bugger.continue()
-    # @subscriptions.add atom.tooltips.add @cwdButton, title: 'Choose File to Debug'
+    cwdButton = document.createElement 'button'
+    cwdButton.classList.add 'btn', 'icon', 'icon-file-directory'
+    cwdButton.textContent = "Choose Directory"
+    cwdButton.addEventListener 'click', => @pickCwd()
     section.appendChild div
     div.appendChild bgroup
-    bgroup.appendChild @cwdButton
-    
+    bgroup.appendChild cwdButton
+
     # Start Button
     startGroup = document.createElement 'div'
     startGroup.classList.add 'block','input-block-item','pull-right','input-block-item--flex'
     @element.appendChild startGroup
-    
-    @startButton = document.createElement 'button'
-    @startButton.classList.add 'btn-lg', 'btn-success', 'icon', 'icon-chevron-right'
-    @startButton.textContent = "Start"
-    @startButton.addEventListener 'click', => @startDebugging()
-    startGroup.appendChild @startButton
+
+    startButton = document.createElement 'button'
+    startButton.classList.add 'btn-lg', 'btn-success', 'icon', 'icon-chevron-right'
+    startButton.textContent = "Start"
+    startButton.addEventListener 'click', => @startDebugging()
+    startGroup.appendChild startButton
 
   pickFile: ->
-    picker = document.createElement 'input'
-    picker.setAttribute 'type', 'file'
-    picker.onchange = () => 
-      if picker.files.length > 0
-        @pathInput.getModel().setBuffer(picker.files[0].path)
-        if @cwdInput.getModel().getBuffer() == ""
-          @cwdInput.getModel().setText(path.dirname(picker.files[0].path))
-    picker.click()
+    openOptions =
+      properties: ['openFile', 'createDirectory']
+      title: 'Select File'
     
+    # Show the open dialog as child window on Windows and Linux, and as
+    # independent dialog on macOS. This matches most native apps.
+    parentWindow =
+      if process.platform is 'darwin'
+        null
+      else
+        require('electron').remote.getCurrentWindow()
+
+    # File dialog defaults to project directory of currently active editor
+    {dialog} = require('electron').remote
+    file = dialog.showOpenDialog(parentWindow, openOptions)
+    if file?
+      @pathInput.model.buffer.setText(file[0])
+
+  pickCwd: ->
+    openOptions =
+      properties: ['openDirectory', 'createDirectory']
+      title: 'Select Folder'
+    
+    # Show the open dialog as child window on Windows and Linux, and as
+    # independent dialog on macOS. This matches most native apps.
+    parentWindow =
+      if process.platform is 'darwin'
+        null
+      else
+        require('electron').remote.getCurrentWindow()
+
+    # File dialog defaults to project directory of currently active editor
+    {dialog} = require('electron').remote
+    folder = dialog.showOpenDialog(parentWindow, openOptions)
+    if folder?
+      @cwdInput.model.buffer.setText(folder[0])
+
   addDebuggerOption: (name) ->
     option = document.createElement('option')
     option.textContent = name
     @selectDebugger.appendChild option
-    
+
   startDebugging: ->
     options = {debugger : null, path: null, args : null, cwd : null}
     if @pathInput.model.buffer.lines[0] != ""
@@ -165,35 +172,15 @@ class CustomDebugView
     if @selectDebugger.value != "auto"
       options.debugger = @selectDebugger.value
     if @argsInput.model.buffer.lines[0] != ""
-      options.args = @parseArgsInput(@argsInput.model.buffer.lines[0])
+      options.args = [ @argsInput.model.buffer.lines[0] ] # TODO: parse into args?
     if @cwdInput.model.buffer.lines[0] != ""
       options.cwd = @cwdInput.model.buffer.lines[0]
-    console.log(options)    
-    @panel.hide()
+    @emitter.emit 'close'
     @bugger.debug(options)
-              
-  setPanel: (@panel) ->
-
-  setBuggers: (@buggers) ->
-    
-  # Returns an object that can be retrieved when package is activated
-  serialize: ->
 
   # Tear down any state and detach
   destroy: ->
-    @subscriptions.dispose()
     @element.remove()
 
   getElement: ->
     @element
-
-  parseArgsInput: (text) ->
-    reg = /(?:")(.*?)(?:")|(?:')(.*?)(?:')|(\S+)/g
-    args = []
-    result = reg.exec(text)
-    while result?
-      args.push(result[1]) if result[1]?
-      args.push(result[2]) if result[2]?
-      args.push(result[3]) if result[3]?
-      result = reg.exec(text)
-    return args

--- a/lib/view/Custom.coffee
+++ b/lib/view/Custom.coffee
@@ -4,9 +4,11 @@ path = require('path');
 module.exports =
 class CustomDebugView
   panel = null
+  bugger = null
   
-  constructor: (serializedState) ->
+  constructor: (bugger) ->
     @subscriptions = new CompositeDisposable()
+    @bugger = bugger
     
     @content()
     @handleEvents()
@@ -54,12 +56,12 @@ class CustomDebugView
     
     @selectDebugger = document.createElement('select')
     @selectDebugger.classList.add 'input-select'
-    option = document.createElement('option')
-    option.textContent = "auto"
-    # TODO: find the installed debuggers and populate this element
     @element.appendChild div
     div.appendChild span
     span.appendChild @selectDebugger
+    
+    option = document.createElement('option')
+    option.textContent = "auto"
     @selectDebugger.appendChild option
   
     # file to Debug
@@ -149,8 +151,15 @@ class CustomDebugView
           @cwdInput.getModel().setText(path.dirname(picker.files[0].path))
     picker.click()
     
+  addDebuggerOption: (name) ->
+    option = document.createElement('option')
+    option.textContent = name
+    @selectDebugger.appendChild option
+              
   setPanel: (@panel) ->
 
+  setBuggers: (@buggers) ->
+    
   # Returns an object that can be retrieved when package is activated
   serialize: ->
 

--- a/lib/view/Custom.coffee
+++ b/lib/view/Custom.coffee
@@ -165,7 +165,7 @@ class CustomDebugView
     if @selectDebugger.value != "auto"
       options.debugger = @selectDebugger.value
     if @argsInput.model.buffer.lines[0] != ""
-      options.args = @argsInput.model.buffer.lines[0]
+      options.args = @parseArgsInput(@argsInput.model.buffer.lines[0])
     if @cwdInput.model.buffer.lines[0] != ""
       options.cwd = @cwdInput.model.buffer.lines[0]
     console.log(options)    
@@ -186,3 +186,14 @@ class CustomDebugView
 
   getElement: ->
     @element
+
+  parseArgsInput: (text) ->
+    reg = /(?:")(.*?)(?:")|(?:')(.*?)(?:')|(\S+)/g
+    args = []
+    result = reg.exec(text)
+    while result?
+      args.push(result[1]) if result[1]?
+      args.push(result[2]) if result[2]?
+      args.push(result[3]) if result[3]?
+      result = reg.exec(text)
+    return args

--- a/lib/view/Custom.coffee
+++ b/lib/view/Custom.coffee
@@ -18,13 +18,14 @@ class CustomDebugView
     fileGroup.classList.add 'block'
     @element.appendChild fileGroup
     
-    pathLabel = document.createElement 'label'
-    pathLabel.textContent = "File to Debug"
-    pathLabel.classList.add 'inline-block'
-    fileGroup.appendChild pathLabel
+    # pathLabel = document.createElement 'label'
+    # pathLabel.textContent = "File to Debug"
+    # pathLabel.classList.add 'inline-block'
+    # fileGroup.appendChild pathLabel
     
-    @pathInput = document.createElement 'input'
-    @pathInput.classList.add 'inline-block', 'input-text'
+    @pathInput = document.createElement 'atom-text-editor'
+    @pathInput.setAttribute(name, value) for name, value of {"tabIndex": -1, "mini": true, "placeholder-text": "Path to the file to debug"}
+    # @pathInput.classList.add 'inline-block', 'input-text'
     @pathInput.type = "text"
     # @subscriptions.add atom.tooltips.add @pathInput, title: 'File to Debug'
     fileGroup.appendChild @pathInput
@@ -40,13 +41,14 @@ class CustomDebugView
     argsGroup.classList.add 'block'
     @element.appendChild argsGroup
     
-    argsLabel = document.createElement 'label'
-    argsLabel.textContent = "Arguments"
-    argsLabel.classList.add 'inline-block'
-    argsGroup.appendChild argsLabel
+    # argsLabel = document.createElement 'label'
+    # argsLabel.textContent = "Arguments"
+    # argsLabel.classList.add 'inline-block'
+    # argsGroup.appendChild argsLabel
     
-    @argsInput = document.createElement 'input'
-    @argsInput.classList.add 'inline-block', 'input-text'
+    @argsInput = document.createElement 'atom-text-editor'
+    @argsInput.setAttribute(name, value) for name, value of {"tabIndex": -1, "mini": true, "placeholder-text": "Arguments to pass to the file being debugged"}
+    # @argsInput.classList.add 'inline-block', 'input-text'
     # @subscriptions.add atom.tooltips.add @argsInput, title: 'Debugger arguements'
     argsGroup.appendChild @argsInput
     
@@ -55,18 +57,14 @@ class CustomDebugView
     cwdGroup.classList.add 'block'
     @element.appendChild cwdGroup
     
-    cwdLabel = document.createElement 'label'
-    cwdLabel.classList.add 'inline-block'
-    cwdLabel.textContent = "Working Directory"
-    cwdGroup.appendChild cwdLabel
-    
-    # @cwdInput = document.createElement 'input'
-    # @cwdInput.classList.add 'inline-block', 'input-text'
-    # # @subscriptions.add atom.tooltips.add @cwdInput, title: 'Working directory path'
-    # cwdGroup.appendChild @cwdInput
-    
+    # cwdLabel = document.createElement 'label'
+    # cwdLabel.classList.add 'inline-block'
+    # cwdLabel.textContent = "Working Directory"
+    # cwdGroup.appendChild cwdLabel
+        
     @cwdInput = document.createElement 'atom-text-editor'
-    @cwdInput.classList.add 'inline-block', 'editor', 'mini'
+    @cwdInput.setAttribute(name, value) for name, value of {"tabIndex": -1, "mini": true, "placeholder-text": "Working directory to use when debugging"}
+    # @cwdInput.classList.add 'inline-block', 'editor', 'mini'
     # @subscriptions.add atom.tooltips.add @cwdInput, title: 'Working directory path'
     cwdGroup.appendChild @cwdInput
     

--- a/lib/view/Custom.coffee
+++ b/lib/view/Custom.coffee
@@ -1,3 +1,4 @@
+path = require('path');
 {CompositeDisposable} = require 'atom'
 
 module.exports =
@@ -53,8 +54,9 @@ class CustomDebugView
     bgroup = document.createElement 'div'
     bgroup.classList.add 'btn-group'
     @pathButton = document.createElement 'button'
-    @pathButton.classList.add 'btn', 'icon', 'icon-file-directory'
-    # @pathButton.addEventListener 'click', -> bugger.continue()
+    @pathButton.classList.add 'btn', 'icon', 'icon-file-binary'
+    @pathButton.textContent = "Choose File"
+    @pathButton.addEventListener 'click', => @pickFile()
     # @subscriptions.add atom.tooltips.add @pathButton, title: 'Choose File to Debug'
     section.appendChild div
     div.appendChild bgroup
@@ -92,6 +94,7 @@ class CustomDebugView
     bgroup.classList.add 'btn-group'
     @cwdButton = document.createElement 'button'
     @cwdButton.classList.add 'btn', 'icon', 'icon-file-directory'
+    @cwdButton.textContent = "Choose Directory"
     # @cwdButton.addEventListener 'click', -> bugger.continue()
     # @subscriptions.add atom.tooltips.add @cwdButton, title: 'Choose File to Debug'
     section.appendChild div
@@ -110,6 +113,16 @@ class CustomDebugView
     # @subscriptions.add atom.tooltips.add @startButton, title: 'Choose working directory'
     startGroup.appendChild @startButton
 
+  pickFile: ->
+    picker = document.createElement 'input'
+    picker.setAttribute 'type', 'file'
+    picker.onchange = () => 
+      if picker.files.length > 0
+        @pathInput.getModel().setBuffer(picker.files[0].path)
+        if @cwdInput.getModel().getBuffer() == ""
+          @cwdInput.getModel().setText(path.dirname(picker.files[0].path))
+    picker.click()
+    
   setPanel: (@panel) ->
   
   # Returns an object that can be retrieved when package is activated

--- a/lib/view/Custom.coffee
+++ b/lib/view/Custom.coffee
@@ -1,21 +1,99 @@
 module.exports =
 class CustomDebugView
   constructor: (serializedState) ->
+    # @subscriptions = new CompositeDisposable()
+    
     # Create root element
     @element = document.createElement('div')
     @element.classList.add('debug-custom')
+    
+    # debugger - Optional. The name of the dbg provider to use. (This can be omitted to auto-detect)
+    # path - Optional. The path to the file to debug
+    # args - Optional. An array of arguments to pass to the file being debugged
+    # cwd - Optional. The working directory to use when debugging
+    # ... - Optional. Custom debugger arguments
+  
+    # file to Debug
+    fileGroup = document.createElement 'div'
+    fileGroup.classList.add 'block'
+    @element.appendChild fileGroup
+    
+    pathLabel = document.createElement 'label'
+    pathLabel.textContent = "File to Debug"
+    pathLabel.classList.add 'inline-block'
+    fileGroup.appendChild pathLabel
+    
+    @pathInput = document.createElement 'input'
+    @pathInput.classList.add 'inline-block', 'input-text'
+    @pathInput.type = "text"
+    # @subscriptions.add atom.tooltips.add @pathInput, title: 'File to Debug'
+    fileGroup.appendChild @pathInput
+    
+    @pathButton = document.createElement 'button'
+    @pathButton.classList.add 'inline-block', 'btn', 'icon', 'icon-file-directory'
+    # @pathButton.addEventListener 'click', -> bugger.continue()
+    # @subscriptions.add atom.tooltips.add @pathButton, title: 'Choose File to Debug'
+    fileGroup.appendChild @pathButton
 
-    # Create message element
-    message = document.createElement('div')
-    message.textContent = "The Your Name Word Count package is Alive! It's ALIVE!"
-    message.classList.add('message')
-    @element.appendChild(message)
+    # args
+    argsGroup = document.createElement 'div'
+    argsGroup.classList.add 'block'
+    @element.appendChild argsGroup
+    
+    argsLabel = document.createElement 'label'
+    argsLabel.textContent = "Arguments"
+    argsLabel.classList.add 'inline-block'
+    argsGroup.appendChild argsLabel
+    
+    @argsInput = document.createElement 'input'
+    @argsInput.classList.add 'inline-block', 'input-text'
+    # @subscriptions.add atom.tooltips.add @argsInput, title: 'Debugger arguements'
+    argsGroup.appendChild @argsInput
+    
+    # working directory for debugger
+    cwdGroup = document.createElement 'div'
+    cwdGroup.classList.add 'block'
+    @element.appendChild cwdGroup
+    
+    cwdLabel = document.createElement 'label'
+    cwdLabel.classList.add 'inline-block'
+    cwdLabel.textContent = "Working Directory"
+    cwdGroup.appendChild cwdLabel
+    
+    # @cwdInput = document.createElement 'input'
+    # @cwdInput.classList.add 'inline-block', 'input-text'
+    # # @subscriptions.add atom.tooltips.add @cwdInput, title: 'Working directory path'
+    # cwdGroup.appendChild @cwdInput
+    
+    @cwdInput = document.createElement 'atom-text-editor'
+    @cwdInput.classList.add 'inline-block', 'editor', 'mini'
+    # @subscriptions.add atom.tooltips.add @cwdInput, title: 'Working directory path'
+    cwdGroup.appendChild @cwdInput
+    
+    @cwdButton = document.createElement 'button'
+    @cwdButton.classList.add 'inline-block', 'btn', 'icon', 'icon-file-directory'
+    # @cwdButton.addEventListener 'click', -> bugger.continue()
+    # @subscriptions.add atom.tooltips.add @cwdButton, title: 'Choose working directory'
+    cwdGroup.appendChild @cwdButton
+    
+    # Start Button
+    startGroup = document.createElement 'div'
+    startGroup.classList.add 'block'
+    @element.appendChild startGroup
+    
+    @startButton = document.createElement 'button'
+    @startButton.classList.add 'btn-lg', 'btn-success', 'icon', 'icon-chevron-right'
+    @startButton.textContent = "Start"
+    # @startButton.addEventListener 'click', -> bugger.continue()
+    # @subscriptions.add atom.tooltips.add @startButton, title: 'Choose working directory'
+    startGroup.appendChild @startButton
 
   # Returns an object that can be retrieved when package is activated
   serialize: ->
 
   # Tear down any state and detach
   destroy: ->
+    # @subscriptions.dispose()
     @element.remove()
 
   getElement: ->

--- a/lib/view/Custom.coffee
+++ b/lib/view/Custom.coffee
@@ -12,9 +12,9 @@ class CustomDebugView
     @handleEvents()
     
   handleEvents: ->
-    @subscriptions.add atom.commands.add @element,
-      'core:close': => @panel?hide()
-      'core:cancel': => @panel?hide()
+    # @subscriptions.add atom.commands.add @element,
+    #   'core:close': => @panel?hide()
+    #   'core:cancel': => @panel?hide()
     
   content: ->
     # Create root element
@@ -30,11 +30,37 @@ class CustomDebugView
     @element.appendChild header
     header.appendChild span
     
+    @closeBtn = document.createElement('span')
+    @closeBtn.classList.add 'header-item','pull-right','btn', 'icon', 'icon-remove-close'
+    span.appendChild @closeBtn
+      # @span 'Finding with Options: '
+      # @span outlet: 'optionsLabel', class: 'options'
+    # @subscriptions.add atom.tooltips.add @closeBtn, title: 'Choose File to Debug'
+    @closeBtn.addEventListener 'click', => @panel?.hide()
+    
     # debugger - Optional. The name of the dbg provider to use. (This can be omitted to auto-detect)
     # path - Optional. The path to the file to debug
     # args - Optional. An array of arguments to pass to the file being debugged
     # cwd - Optional. The working directory to use when debugging
     # ... - Optional. Custom debugger arguments
+    
+    div = document.createElement('div')
+    span = document.createElement('span')
+    label = document.createElement('label')
+    # label.classList.add 'header-item'
+    label.textContent = "Select Debugger"
+    span.appendChild label
+    div.appendChild span
+    
+    @selectDebugger = document.createElement('select')
+    @selectDebugger.classList.add 'input-select'
+    option = document.createElement('option')
+    option.textContent = "auto"
+    # TODO: find the installed debuggers and populate this element
+    @element.appendChild div
+    div.appendChild span
+    span.appendChild @selectDebugger
+    @selectDebugger.appendChild option
   
     # file to Debug
     section = document.createElement 'section'
@@ -124,7 +150,7 @@ class CustomDebugView
     picker.click()
     
   setPanel: (@panel) ->
-  
+
   # Returns an object that can be retrieved when package is activated
   serialize: ->
 

--- a/lib/view/Custom.coffee
+++ b/lib/view/Custom.coffee
@@ -1,5 +1,5 @@
 path = require('path');
-{Emitter, promptForPath} = require 'atom'
+{Emitter} = require 'atom'
 
 module.exports =
 class CustomDebugView
@@ -16,7 +16,7 @@ class CustomDebugView
     @element.setAttribute("tabIndex", -1)
     @element.classList.add('debug-custom')
 
-    header = document.createElement 'div' 
+    header = document.createElement 'div'
     header.classList.add 'panel-heading'
     header.textContent = "Configure Debug Session"
     @element.appendChild header
@@ -29,29 +29,32 @@ class CustomDebugView
       @emitter.emit 'close'
 
     div = document.createElement('div')
-    div.classList.add 'input-block-item', 'input-block-item--flex'
-    span = document.createElement('span')
+    div.classList.add 'input-block-item', 'labeled-block'
     label = document.createElement('label')
     label.textContent = "Select Debugger"
-    span.appendChild label
-    div.appendChild span
+    div.appendChild label
 
     @selectDebugger = document.createElement('select')
-    @selectDebugger.classList.add 'input-select'
+    @selectDebugger.classList.add 'input-select', 'input-select-item'
     @element.appendChild div
-    div.appendChild span
-    span.appendChild @selectDebugger
+    div.appendChild @selectDebugger
 
     option = document.createElement('option')
     option.textContent = "auto"
     @selectDebugger.appendChild option
+
+    body = document.createElement('div')
+    body.classList.add('body')
+    inputBody = document.createElement('div')
+    inputBody.classList.add 'input-inline-block'
+    body.appendChild inputBody
 
     # file to Debug
     section = document.createElement 'section'
     section.classList.add 'input-block'
     fileGroup = document.createElement 'div'
     fileGroup.classList.add 'input-block-item', 'input-block-item--flex', 'editor-container'
-    @element.appendChild section
+    inputBody.appendChild section
     section.appendChild fileGroup
 
     @pathInput = document.createElement 'atom-text-editor'
@@ -64,7 +67,7 @@ class CustomDebugView
     bgroup = document.createElement 'div'
     bgroup.classList.add 'btn-group'
     pathButton = document.createElement 'button'
-    pathButton.classList.add 'btn', 'icon', 'icon-file-binary'
+    pathButton.classList.add 'btn-item', 'btn', 'icon', 'icon-file-binary'
     pathButton.textContent = "Choose File"
     pathButton.addEventListener 'click', => @pickFile()
     section.appendChild div
@@ -76,7 +79,7 @@ class CustomDebugView
     section.classList.add 'input-block'
     argsGroup = document.createElement 'div'
     argsGroup.classList.add 'input-block-item', 'input-block-item--flex', 'editor-container'
-    @element.appendChild section
+    inputBody.appendChild section
     section.appendChild argsGroup
 
     @argsInput = document.createElement 'atom-text-editor'
@@ -89,7 +92,7 @@ class CustomDebugView
     section.classList.add 'input-block'
     cwdGroup = document.createElement 'div'
     cwdGroup.classList.add 'input-block-item', 'input-block-item--flex', 'editor-container'
-    @element.appendChild section
+    inputBody.appendChild section
     section.appendChild cwdGroup
 
     @cwdInput = document.createElement 'atom-text-editor'
@@ -102,7 +105,7 @@ class CustomDebugView
     bgroup = document.createElement 'div'
     bgroup.classList.add 'btn-group'
     cwdButton = document.createElement 'button'
-    cwdButton.classList.add 'btn', 'icon', 'icon-file-directory'
+    cwdButton.classList.add 'btn-item', 'btn', 'icon', 'icon-file-directory'
     cwdButton.textContent = "Choose Directory"
     cwdButton.addEventListener 'click', => @pickCwd()
     section.appendChild div
@@ -110,21 +113,22 @@ class CustomDebugView
     bgroup.appendChild cwdButton
 
     # Start Button
-    startGroup = document.createElement 'div'
-    startGroup.classList.add 'block','input-block-item','pull-right','input-block-item--flex'
-    @element.appendChild startGroup
+    div = document.createElement 'div'
+    div.classList.add 'inline-block-start'
+    body.appendChild div
+    @element.appendChild body
 
     startButton = document.createElement 'button'
     startButton.classList.add 'btn-lg', 'btn-success', 'icon', 'icon-chevron-right'
     startButton.textContent = "Start"
     startButton.addEventListener 'click', => @startDebugging()
-    startGroup.appendChild startButton
+    div.appendChild startButton
 
   pickFile: ->
     openOptions =
       properties: ['openFile', 'createDirectory']
       title: 'Select File'
-    
+
     # Show the open dialog as child window on Windows and Linux, and as
     # independent dialog on macOS. This matches most native apps.
     parentWindow =
@@ -143,7 +147,7 @@ class CustomDebugView
     openOptions =
       properties: ['openDirectory', 'createDirectory']
       title: 'Select Folder'
-    
+
     # Show the open dialog as child window on Windows and Linux, and as
     # independent dialog on macOS. This matches most native apps.
     parentWindow =

--- a/lib/view/Custom.coffee
+++ b/lib/view/Custom.coffee
@@ -47,6 +47,7 @@ class CustomDebugView
     # ... - Optional. Custom debugger arguments
     
     div = document.createElement('div')
+    div.classList.add 'input-block-item', 'input-block-item--flex'
     span = document.createElement('span')
     label = document.createElement('label')
     # label.classList.add 'header-item'
@@ -131,14 +132,13 @@ class CustomDebugView
     
     # Start Button
     startGroup = document.createElement 'div'
-    startGroup.classList.add 'block'
+    startGroup.classList.add 'block','input-block-item','pull-right','input-block-item--flex'
     @element.appendChild startGroup
     
     @startButton = document.createElement 'button'
     @startButton.classList.add 'btn-lg', 'btn-success', 'icon', 'icon-chevron-right'
     @startButton.textContent = "Start"
-    # @startButton.addEventListener 'click', -> bugger.continue()
-    # @subscriptions.add atom.tooltips.add @startButton, title: 'Choose working directory'
+    @startButton.addEventListener 'click', => @startDebugging()
     startGroup.appendChild @startButton
 
   pickFile: ->
@@ -155,6 +155,22 @@ class CustomDebugView
     option = document.createElement('option')
     option.textContent = name
     @selectDebugger.appendChild option
+    
+  startDebugging: ->
+    options = {debugger : null, path: null, args : null, cwd : null}
+    if @pathInput.model.buffer.lines[0] != ""
+      options.path = @pathInput.model.buffer.lines[0]
+    else
+      return
+    if @selectDebugger.value != "auto"
+      options.debugger = @selectDebugger.value
+    if @argsInput.model.buffer.lines[0] != ""
+      options.args = @argsInput.model.buffer.lines[0]
+    if @cwdInput.model.buffer.lines[0] != ""
+      options.cwd = @cwdInput.model.buffer.lines[0]
+    console.log(options)    
+    @panel.hide()
+    @bugger.debug(options)
               
   setPanel: (@panel) ->
 

--- a/menus/debug.cson
+++ b/menus/debug.cson
@@ -9,6 +9,8 @@ menu: [
     submenu: [
       label: 'Debug'
       submenu: [
+        { type: 'Debug ...', command: 'dbg:custom-debug' }
+        { type: 'separator' }
         { label: 'Continue / Pause', command: 'dbg:pause-continue' }
         { label: 'Step Over', command: 'dbg:step-over' }
         { label: 'Step in', command: 'dbg:step-in' }

--- a/styles/debug.less
+++ b/styles/debug.less
@@ -102,6 +102,7 @@ atom-text-editor::shadow {
 .debug-custom {
 	@min-width: 200px;
 	@item-width: 260px;
+	@button-width: 150px;
 	.panel-heading {
 		position: relative;
 		cursor: default;
@@ -138,21 +139,11 @@ atom-text-editor::shadow {
   }
 	.btn-group {
     display: flex;
-    flex: 1;
-    .btn {
-      flex: 1;
-			line-height: 1;
-    }
-    & + .btn-group {
-      margin-left: @component-padding;
-    }
+		flex: 1 1 @button-width;
+		min-width: @button-width;
   }
-	.btn > .icon {
-    width: 20px;
-    height: 16px;
-    vertical-align: middle;
-    fill: currentColor;
-    stroke: currentColor;
+	.btn-item {
+		flex: auto;
   }
 	.input-block {
 		display: flex;
@@ -160,6 +151,25 @@ atom-text-editor::shadow {
 		width: 100%;
 		min-width: @min-width;
 	}
+	.body {
+		display: flex;
+	}
+	.labeled-block {
+		align-items: center;
+	}
+	.input-select-item {
+		padding-left: @component-padding / 2;
+		margin-left: @component-padding;
+	}
+	.input-inline-block {
+    display: inline-block;
+		flex: auto;
+  }
+	.inline-block-start {
+    display: flex;
+		flex: none;
+		padding: @component-padding / 2;
+  }
 	.input-block-item {
     display: flex;
 		flex: 1;

--- a/styles/debug.less
+++ b/styles/debug.less
@@ -98,3 +98,53 @@ atom-text-editor::shadow {
 		width: 250px;
 	}
 }
+
+.debug-custom {
+	@min-width: 200px;
+	@item-width: 260px;
+	.header {
+    padding: @component-padding/4 @component-padding/2;
+    min-width: @min-width;
+  }
+  .header-item {
+    margin: @component-padding/4 0;
+  }
+	.btn-group {
+    display: flex;
+    flex: 1;
+    .btn {
+      flex: 1;
+			line-height: 1;
+    }
+    & + .btn-group {
+      margin-left: @component-padding;
+    }
+  }
+	.btn > .icon {
+    width: 20px;
+    height: 16px;
+    vertical-align: middle;
+    fill: currentColor;
+    stroke: currentColor;
+  }
+	.input-block {
+		display: flex;
+		flex-wrap: wrap;
+		width: 100%;
+		min-width: @min-width;
+	}
+	.input-block-item {
+    display: flex;
+		flex: 1;
+		padding: @component-padding / 2;
+  }
+  .input-block-item--flex {
+    flex: 100 1 @item-width;
+  }
+	.editor-container {
+    position: relative;
+    atom-text-editor {
+      width: 100%;
+    }
+	}
+}

--- a/styles/debug.less
+++ b/styles/debug.less
@@ -102,6 +102,33 @@ atom-text-editor::shadow {
 .debug-custom {
 	@min-width: 200px;
 	@item-width: 260px;
+	.panel-heading {
+		position: relative;
+		cursor: default;
+
+		.action-close {
+			border: 0 none;
+			background: transparent;
+			position: absolute;
+			top: 0;
+			right: 0;
+			height: 100%;
+			cursor: pointer;
+
+			&::before {
+				width: 28px;
+				margin-right: 0;
+				text-align: center;
+				vertical-align: middle;
+			}
+			&::after {
+				content: '';
+				display: inline-block;
+				height: 100%;
+				vertical-align: middle;
+			}
+		}
+	}
 	.header {
     padding: @component-padding/4 @component-padding/2;
     min-width: @min-width;


### PR DESCRIPTION
Adds a panel that allows the user to specify debugger, file to debug, arguments, and working directory.

Implements 31i73/atom-dbg-gdb#6

Currently the arguments line just takes the single line and passes it to the backend. This avoids having to parse into separate arguments only to have the backend reassemble them into a single string.

![customdebugpanel](https://cloud.githubusercontent.com/assets/8310169/19017783/ce765904-8815-11e6-83eb-5bc751a33f36.png)
