### PR TITLE
Config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Current available backends:
 ## Commands:
 
 `dbg:custom-debug` - Opens the debug configuration panel  
+`dbg:select-config` - Opens select list with debug configuration from .atom-debug files, starts debug session when a configuration is selected  
 `dbg:debug` - Begins a new debug session, continues a paused, or opens the config panel if no settings present  
 `dbg:continue` - Continue  
 `dbg:pause` - Pause  
@@ -34,6 +35,31 @@ Current available backends:
 `dbg:stop` - Stop debugging  
 `dbg:toggle-breakpoint` - Toggle a breakpoint on the currently active line  
 `dbg:clear-breakpoints` - Clear all breakpoints  
+
+## Advanced Debug Configurations
+
+If you need access to more options than are available in the configuration panel or you want to save different debug configurations for easy use, you can create custom configuration files in the root directory of your project.
+
+Supported Formats:
+ * JSON `.atom-debug.json`
+ * CSON `.atom-debug.cson`
+
+Example:
+
+This cson example creates debug configuration `client` and `sever` which can then be started with the `dbg:select-config` command. Refer to specific backend documentation for complete list of supported options.
+```
+client:
+	debugger: 'dbg-gdb'
+	cwd: 'client'
+	path: 'client/bin'
+	args: ['--connect', '1234']
+
+server:
+	debugger: 'dbg-gdb'
+	cwd: 'server'
+	path: 'server/bin'
+	args: ['--port', '1234']
+```
 
 ## Service: `dbg`
 

--- a/lib/debugConfigurations.coffee
+++ b/lib/debugConfigurations.coffee
@@ -1,0 +1,47 @@
+fs = require 'fs'
+path = require 'path'
+CSON = require 'cson-parser'
+chokidar = require 'chokidar'
+
+module.exports =
+class CustomDebugConfigs
+	constructor: () ->
+		@debugConfigs = {}
+		@watcher = null
+
+		@startWatching atom.project.getPaths()
+
+		atom.project.onDidChangePaths (projectPaths) =>
+			@debugConfigs = {}
+			@watcher.close
+			@startWatching projectPaths
+
+	startWatching: (dirs) ->
+		globs = [path.resolve p,".atom-debug.[jc]son" for p in dirs] # only watch in directories
+
+		#FIXME: this glob works, but for some reason it grabs more files than expected
+		# globs = [path.resolve p, "**",".atom-debug.[jc]son" for p in dirs] # watch recursivly in directories
+
+		@watcher = chokidar.watch globs
+		@watcher.on 'add', (f) =>
+			console.log "now watching! " + f
+			@updateConfig f
+			console.log @updateConfig
+
+		@watcher.on 'change', (f) =>
+			console.log "something changed!" + f
+			@updateConfig f
+
+		@watcher.on 'unlink', (f) =>
+			console.log "its been removed!" + f
+			delete @debugConfigs[f]
+
+	destructor: () ->
+		@watcher.close
+
+	updateConfig: (f) ->
+		switch path.extname f
+			when '.json'
+				@debugConfigs[f] = JSON.parse fs.readFileSync f
+			when '.cson'
+				@debugConfigs[f] = CSON.parse fs.readFileSync f

--- a/lib/debugConfigurations.coffee
+++ b/lib/debugConfigurations.coffee
@@ -17,24 +17,13 @@ class CustomDebugConfigs
 			@startWatching projectPaths
 
 	startWatching: (dirs) ->
-		globs = [path.resolve p,".atom-debug.[jc]son" for p in dirs] # only watch in directories
-
-		#FIXME: this glob works, but for some reason it grabs more files than expected
+		#TODO: this glob works, but for some reason it grabs more files than expected
 		# globs = [path.resolve p, "**",".atom-debug.[jc]son" for p in dirs] # watch recursivly in directories
-
+		globs = [path.resolve p,".atom-debug.[jc]son" for p in dirs] # only watch in directories
 		@watcher = chokidar.watch globs
-		@watcher.on 'add', (f) =>
-			console.log "now watching! " + f
-			@updateConfig f
-			console.log @updateConfig
-
-		@watcher.on 'change', (f) =>
-			console.log "something changed!" + f
-			@updateConfig f
-
-		@watcher.on 'unlink', (f) =>
-			console.log "its been removed!" + f
-			delete @debugConfigs[f]
+		@watcher.on 'add', (f) => @updateConfig f
+		@watcher.on 'change', (f) => @updateConfig f
+		@watcher.on 'unlink', (f) => delete @debugConfigs[f]
 
 	destructor: () ->
 		@watcher.close
@@ -45,3 +34,9 @@ class CustomDebugConfigs
 				@debugConfigs[f] = JSON.parse fs.readFileSync f
 			when '.cson'
 				@debugConfigs[f] = CSON.parse fs.readFileSync f
+
+	getConfigs: ->
+		configs = {}
+		for f of @debugConfigs
+			Object.assign(configs, @debugConfigs[f])
+		return configs

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -2,6 +2,7 @@ Ui = require './Ui'
 Toolbar = require './view/Toolbar'
 Sidebar = require './view/Sidebar'
 CustomPanel = require './view/CustomPanel'
+CustomDebugConfigs = require './debugConfigurations'
 
 {CompositeDisposable, Emitter} = require 'atom'
 
@@ -18,6 +19,7 @@ module.exports = Debug =
 	buggers: []
 	activeBugger: null
 	breakpoints: []
+	debugConfigs: null
 
 	activate: (state) ->
 		@provider = new Emitter()
@@ -112,6 +114,8 @@ module.exports = Debug =
 		if state.breakpoints
 			for breakpoint in state.breakpoints
 				@addBreakpoint breakpoint.path, breakpoint.line
+
+		@debugConfigs = new CustomDebugConfigs
 
 	deactivate: ->
 		@disposable.dispose()

--- a/lib/view/ConfigList.coffee
+++ b/lib/view/ConfigList.coffee
@@ -1,0 +1,28 @@
+{SelectListView, $$} = require 'atom-space-pen-views'
+{Emitter} = require 'atom'
+
+module.exports =
+class ConfigList extends SelectListView
+	initialize: () ->
+		super
+		@emitter = new Emitter()
+		@configs = {}
+
+	viewForItem: (item) ->
+		$$ -> @li(item)
+
+	setConfigs: (@configs) ->
+		configNames = []
+		configNames.push name for name of @configs
+		@setItems configNames
+
+	awaitSelection: ->
+		return new Promise (resolve, reject) =>
+			@resolveFunction = resolve
+
+	cancel: ->
+		@emitter.emit 'close'
+
+	confirmed: (item) ->
+		@emitter.emit 'close'
+		@resolveFunction @configs[item] if @resolveFunction?

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "cson-parser": "^1.3.0",
-    "chokidar": "^1.6.0"
+    "chokidar": "^1.6.0",
+    "atom-space-pen-views": "^2.2.0"
   },
   "providedServices": {
     "dbg": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "cson-parser": "^1.3.0",
+    "chokidar": "^1.6.0"
+  },
   "providedServices": {
     "dbg": {
       "description": "Provides debug support in Atom",


### PR DESCRIPTION
define debug configuration in  .atom-debug.json/cson configuration files and start a debug session by selecting a configuration from a select-list. Addresses issue #7

Allows for multiple config files, currently they are smashed together, so having multiple configs with same name will work, but they will overwrite the previous one.

Config files must be in the root project directory. The glob can be made recursive, but its grabbing more than just .atom.build files for some reason.

feel free to rename/refactor things