### PR TITLE
SelectListView from atom-select-list not atom-space-pen-views

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -138,9 +138,6 @@ module.exports = Debug =
 
 		@configManager = new ConfigManager
 		@configList = new ConfigList this
-		@atomConfigList = atom.workspace.addModalPanel item: @configList.selectListView, visible: false
-		@configList.emitter.on 'close', =>
-			@atomConfigList.hide()
 
 	deactivate: ->
 		@disposable.dispose()
@@ -260,8 +257,7 @@ module.exports = Debug =
 
 	selectConfig: ->
 		@configList.setConfigs @configManager.getConfigOptions()
-		@atomConfigList.show()
-		@configList.selectListView.focus()
+		@configList.show()
 
 	continue: ->
 		unless @ui.isPaused then return

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -138,7 +138,7 @@ module.exports = Debug =
 
 		@configManager = new ConfigManager
 		@configList = new ConfigList this
-		@atomConfigList = atom.workspace.addModalPanel item: @configList, visible: false
+		@atomConfigList = atom.workspace.addModalPanel item: @configList.selectListView, visible: false
 		@configList.emitter.on 'close', =>
 			@atomConfigList.hide()
 
@@ -261,7 +261,7 @@ module.exports = Debug =
 	selectConfig: ->
 		@configList.setConfigs @configManager.getConfigOptions()
 		@atomConfigList.show()
-		@configList.focusFilterEditor()
+		@configList.selectListView.focus()
 
 	continue: ->
 		unless @ui.isPaused then return

--- a/lib/view/ConfigList.coffee
+++ b/lib/view/ConfigList.coffee
@@ -1,22 +1,31 @@
-{SelectListView, $$} = require 'atom-space-pen-views'
+{SelectListView} = require 'atom-select-list'
 {Emitter} = require 'atom'
 
 module.exports =
-class ConfigList extends SelectListView
-	initialize: (bugger) ->
-		super
+class ConfigList
+	constructor: (bugger) ->
 		@emitter = new Emitter
 		@bugger = bugger
+		@selectListView = new SelectListView
+			filterKeyForItems: (item) => item.name
+			elementForItem: (item) =>
+				element = document.createElement 'li'
+				if item.description
+					element.classList.add 'two-lines'
+					div = document.createElement 'div'
+					div.classList.add 'primary-line'
+					div.textContent = item.name
+					element.appendChild div
+					div = document.createElement 'div'
+					div.classList.add 'secondary-line'
+					div.textContent = item.description
+					element.appendChild div
+				else
+					element.textContent = item.name
+				return element
 
-	viewForItem: (item) ->
-		if item.description
-			$$ -> @li 'class':'two-lines', =>
-				@div 'class':'primary-line', item.name
-				@div 'class':'secondary-line', item.description
-		else
-			$$ -> @li item.name
-
-	getFilterKey: -> 'name'
+	destroy: ->
+		@selectListView.destroy()
 
 	setConfigs: (configs) ->
 		items = configs.slice()

--- a/lib/view/ConfigList.coffee
+++ b/lib/view/ConfigList.coffee
@@ -1,10 +1,8 @@
 SelectListView = require 'atom-select-list'
-{Emitter} = require 'atom'
 
 module.exports =
 class ConfigList
 	constructor: (bugger) ->
-		@emitter = new Emitter
 		@bugger = bugger
 		@selectListView = new SelectListView
 			items: []
@@ -25,16 +23,17 @@ class ConfigList
 					element.textContent = item.name
 				return element
 			didConfirmSelection: (item) =>
-				@emitter.emit 'close'
+				@hide()
 				if item.config
 					@bugger.debug item.config
 				else if item.callback
 					item.callback()
-			didCancelSelection: =>
-				@emitter.emit 'close'
+			didCancelSelection: => @hide()
+		@modelPanel = atom.workspace.addModalPanel item: @selectListView, visible: false
 
 	destroy: ->
 		@selectListView.destroy()
+		@modelPanel.destroy()
 
 	setConfigs: (configs) ->
 		items = configs.slice()
@@ -43,3 +42,9 @@ class ConfigList
 		items.push name:'Edit', description:'Edit your project debug settings', callback: => @bugger.openConfigFile()
 
 		@selectListView.update items: items
+
+	hide: -> @modelPanel.hide()
+
+	show: ->
+		@modelPanel.show()
+		@selectListView.focus()

--- a/lib/view/ConfigList.coffee
+++ b/lib/view/ConfigList.coffee
@@ -1,4 +1,4 @@
-{SelectListView} = require 'atom-select-list'
+SelectListView = require 'atom-select-list'
 {Emitter} = require 'atom'
 
 module.exports =
@@ -7,7 +7,8 @@ class ConfigList
 		@emitter = new Emitter
 		@bugger = bugger
 		@selectListView = new SelectListView
-			filterKeyForItems: (item) => item.name
+			items: []
+			filterKeyForItems: (item) => item.nameb
 			elementForItem: (item) =>
 				element = document.createElement 'li'
 				if item.description
@@ -23,6 +24,14 @@ class ConfigList
 				else
 					element.textContent = item.name
 				return element
+			didConfirmSelection: (item) =>
+				@emitter.emit 'close'
+				if item.config
+					@bugger.debug item.config
+				else if item.callback
+					item.callback()
+			didCancelSelection: =>
+				@emitter.emit 'close'
 
 	destroy: ->
 		@selectListView.destroy()
@@ -33,15 +42,4 @@ class ConfigList
 		items.push name:'Custom', description:'Configure a custom debug session', callback: => @bugger.customDebug()
 		items.push name:'Edit', description:'Edit your project debug settings', callback: => @bugger.openConfigFile()
 
-		@setItems items
-
-	cancel: ->
-		@emitter.emit 'close'
-
-	confirmed: (item) ->
-		@emitter.emit 'close'
-
-		if item.config
-			@bugger.debug item.config
-		else if item.callback
-			item.callback()
+		@selectListView.update items: items

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "cson-parser": "^1.3.0",
     "chokidar": "^1.6.0",
-    "atom-space-pen-views": "^2.2.0"
+    "atom-select-list": "^0.0.14"
   },
   "providedServices": {
     "dbg": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "cson-parser": "^1.3.0",
     "chokidar": "^1.6.0",
-    "atom-select-list": "^0.0.14"
+    "atom-select-list": "^0.0.16"
   },
   "providedServices": {
     "dbg": {


### PR DESCRIPTION
Possibly the most pointless pull request. No new features, no bug fixes.

atom-space-pen-views bugs me because it feels like the depreciated views that are no longer used by atom core, although many other packages use it.

The atom-select-list package is used in atom core, [albeit only once](https://github.com/atom/atom/blob/9efae86238abb0cae0ddaa855c1be707290c1917/src/reopen-project-list-view.js#L3).

This commit moved the modalpanel into ConfigList. The [previous commit](https://github.com/vanossj/atom-dbg/commit/05676cf8b411ae9a1ee02c87c3d9aef62f4be1fb) is functional, but with the modelpanel still in Debug.

Feel free to use either, or neither.