### PR TITLE
correctly save selected debugger when updating debugger list

### DIFF
--- a/lib/view/CustomPanel.coffee
+++ b/lib/view/CustomPanel.coffee
@@ -190,13 +190,14 @@ class CustomPanel
 	updateDebuggers: ->
 		selected = null
 		while @debuggerList.firstChild
-			if @debuggerList.firstChild.selected
+			if selected==null and @debuggerList.firstChild.selected
 				selected = @debuggerList.firstChild.value
 			@debuggerList.removeChild @debuggerList.firstChild
 
 		option = document.createElement 'option'
 		option.textContent = 'automatic'
 		option.value = ''
+		option.selected = selected==option.value or selected==null
 		@debuggerList.appendChild option
 
 		for bugger in @bugger.buggers


### PR DESCRIPTION
removing a selected option results in a new option being selected and then subsequently saved as the 'selected' option before being removed.

Actual behavior is the the penultimate option would be set as the selected option regardless of what the original selected option was.

This patch only saves, and reselects, the first selected option.

However, in practice this function is only called when starting up, and 'automatic' is always the selected item coming out of this function. Checking for, saving, and maintaining the same selected option doesn't seem necessary.